### PR TITLE
Create imageNet objects with fp16 support disabled.

### DIFF
--- a/imageNet.cpp
+++ b/imageNet.cpp
@@ -1,7 +1,7 @@
 /*
  * http://github.com/dusty-nv/jetson-inference
  */
- 
+
 #include "imageNet.h"
 #include "cudaMappedMemory.h"
 #include "cudaResize.h"
@@ -30,37 +30,44 @@ imageNet::~imageNet()
 
 
 // Create
-imageNet* imageNet::Create( imageNet::NetworkType networkType )
+imageNet* imageNet::Create( imageNet::NetworkType networkType, bool disable_fp16 )
 {
 	imageNet* net = new imageNet();
 	
 	if( !net )
 		return NULL;
-	
+
+	if( disable_fp16 )
+		net->DisableFP16();
+
 	if( !net->init(networkType) )
 	{
 		printf("imageNet -- failed to initialize.\n");
 		return NULL;
 	}
-	
+
 	return net;
 }
 
 
 imageNet* imageNet::Create( const char* prototxt_path, const char* model_path, const char* mean_binary,
-							const char* class_path, const char* input, const char* output )
+							const char* class_path, const char* input, const char* output,
+							bool disable_fp16 )
 {
 	imageNet* net = new imageNet();
 	
 	if( !net )
 		return NULL;
-	
+
+	if( disable_fp16 )
+		net->DisableFP16();
+
 	if( !net->init(prototxt_path, model_path, mean_binary, class_path, input, output) )
 	{
 		printf("imageNet -- failed to initialize.\n");
 		return NULL;
 	}
-	
+
 	return net;
 }
 	
@@ -91,7 +98,7 @@ bool imageNet::init(const char* prototxt_path, const char* model_path, const cha
 	printf("%s initialized.\n", model_path);
 	return true;
 }
-							 
+
 
 // loadClassInfo
 bool imageNet::loadClassInfo( const char* filename )

--- a/imageNet.h
+++ b/imageNet.h
@@ -27,7 +27,7 @@ public:
 	/**
 	 * Load a new network instance
 	 */
-	static imageNet* Create( NetworkType networkType=GOOGLENET );
+	static imageNet* Create( NetworkType networkType=GOOGLENET, bool disable_fp16=false );
 	
 	/**
 	 * Load a new network instance
@@ -38,7 +38,8 @@ public:
 	 * @param input Name of the input layer blob.
 	 */
 	static imageNet* Create( const char* prototxt_path, const char* model_path, const char* mean_binary,
-							 const char* class_labels, const char* input="data", const char* output="prob" );
+							const char* class_labels, const char* input="data", const char* output="prob",
+							bool disable_fp16=false );
 	
 	/**
 	 * Destroy


### PR DESCRIPTION
When creating `imageNet` objects, it's currently not possible to disable fp16 support (e.g. to build fp32 models on Jetson TX1).

Using this patch, it's possible to create one `imageNet` object with fp16 support and another `imageNet` object with fp32 support, without recompiling the `jetson-inference` library. (However, care must be taken to remove the cached model in between creating the objects.)