### PR TITLE
Updated github repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ sudo apt-get install git cmake
 
 Then clone the jetson-inference repo:
 ``` bash
-git clone http://github.org/dusty-nv/jetson-inference
+git clone http://github.com/dusty-nv/jetson-inference
 ```
 
 #### 2. Configuring


### PR DESCRIPTION
Changed `git clone http://github.org/dusty-nv/jetson-inference` to `git clone http://github.com/dusty-nv/jetson-inference`