### PR TITLE
Add Qt4 and GLEW dependencies to Jetson environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ The latest source can be obtained from [GitHub](http://github.com/dusty-nv/jetso
 > &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;> Jetson TX1 - JetPack 2.3.1 / L4T R24.2.1 aarch64 (Ubuntu 16.04 LTS)
       
 #### Cloning the Repo
-To obtain the repository, navigate to a folder of your choosing on the Jetson.  First, make sure git and cmake are installed locally:
+To obtain the repository, navigate to a folder of your choosing on the Jetson.  First, make sure git and cmake as well as some dependency libraries are installed locally:
 
 ``` bash
-$ sudo apt-get install git cmake
+$ sudo apt-get install git cmake libqt4-dev libqt4-dev-bin libglew-dev
 ```
 
 Then clone the jetson-inference repo:


### PR DESCRIPTION
A freshly flashed Jetpack 3 Jetson TX2 does not have QT4 or GLEW, which are needed for jetson-inference to actually build.
(Well, at least mine didn't :-)