### PR TITLE
Image mean subtraction support

### DIFF
--- a/imageNet.cpp
+++ b/imageNet.cpp
@@ -7,7 +7,6 @@
 #include "cudaResize.h"
 #include "commandLine.h"
 
-
 // constructor
 imageNet::imageNet() : tensorNet()
 {
@@ -93,6 +92,8 @@ bool imageNet::init( imageNet::NetworkType networkType, uint32_t maxBatchSize )
 		return init( "networks/googlenet.prototxt", "networks/bvlc_googlenet.caffemodel", NULL, "networks/ilsvrc12_synset_words.txt", IMAGENET_DEFAULT_INPUT, IMAGENET_DEFAULT_OUTPUT, maxBatchSize );
 	else if( networkType == imageNet::GOOGLENET_12 )
 		return init( "networks/GoogleNet-ILSVRC12-subset/deploy.prototxt", "networks/GoogleNet-ILSVRC12-subset/snapshot_iter_184080.caffemodel", NULL, "networks/GoogleNet-ILSVRC12-subset/labels.txt", IMAGENET_DEFAULT_INPUT, "softmax", maxBatchSize );
+	else
+		return init( "networks/googlenet.prototxt", "networks/bvlc_googlenet.caffemodel", NULL, "networks/ilsvrc12_synset_words.txt", IMAGENET_DEFAULT_INPUT, IMAGENET_DEFAULT_OUTPUT, maxBatchSize );
 }
 
 
@@ -106,6 +107,7 @@ bool imageNet::init(const char* prototxt_path, const char* model_path, const cha
 	printf("imageNet -- loading classification network model from:\n");
 	printf("         -- prototxt     %s\n", prototxt_path);
 	printf("         -- model        %s\n", model_path);
+	printf("         -- mean_binary  %s\n", mean_binary);
 	printf("         -- class_labels %s\n", class_path);
 	printf("         -- input_blob   '%s'\n", input);
 	printf("         -- output_blob  '%s'\n", output);
@@ -180,6 +182,7 @@ imageNet* imageNet::Create( int argc, char** argv )
 		const char* input    = cmdLine.GetString("input_blob");
 		const char* output   = cmdLine.GetString("output_blob");
 		const char* out_bbox = cmdLine.GetString("output_bbox");
+		const char* mean     = cmdLine.GetString("mean_binary");
 		
 		if( !input ) 	input    = IMAGENET_DEFAULT_INPUT;
 		if( !output )  output   = IMAGENET_DEFAULT_OUTPUT;
@@ -189,7 +192,7 @@ imageNet* imageNet::Create( int argc, char** argv )
 		if( maxBatchSize < 1 )
 			maxBatchSize = 2;
 
-		return imageNet::Create(prototxt, modelName, NULL, labels, input, output, maxBatchSize);
+		return imageNet::Create(prototxt, modelName, mean, labels, input, output, maxBatchSize);
 	}
 
 	// create from pretrained model
@@ -261,7 +264,7 @@ bool imageNet::loadClassInfo( const char* filename )
 
 // from imageNet.cu
 cudaError_t cudaPreImageNetMean( float4* input, size_t inputWidth, size_t inputHeight, float* output, size_t outputWidth, size_t outputHeight, const float3& mean_value );
-					
+cudaError_t cudaPreImageNetMean( float4* input, size_t inputWidth, size_t inputHeight, float* output, size_t outputWidth, size_t outputHeight, float* mean_binary );
 					
 // Classify
 int imageNet::Classify( float* rgba, uint32_t width, uint32_t height, float* confidence )
@@ -272,13 +275,22 @@ int imageNet::Classify( float* rgba, uint32_t width, uint32_t height, float* con
 		return -1;
 	}
 
-	
-	// downsample and convert to band-sequential BGR
-	if( CUDA_FAILED(cudaPreImageNetMean((float4*)rgba, width, height, mInputCUDA, mWidth, mHeight,
-								 make_float3(104.0069879317889f, 116.66876761696767f, 122.6789143406786f))) )
+	if( !mMeanCPU )
 	{
-		printf("imageNet::Classify() -- cudaPreImageNetMean failed\n");
-		return -1;
+		// downsample and convert to band-sequential BGR
+		if( CUDA_FAILED(cudaPreImageNetMean((float4*)rgba, width, height, mInputCUDA, mWidth, mHeight,
+									 make_float3(104.0069879317889f, 116.66876761696767f, 122.6789143406786f))) )
+		{
+			printf("imageNet::Classify() -- cudaPreImageNetMean failed\n");
+			return -1;
+		}
+	} else {
+		if( CUDA_FAILED(cudaPreImageNetMean((float4*)rgba, width, height, mInputCUDA, mWidth, mHeight,
+									 mMeanCUDA)) )
+		{
+			printf("imageNet::Classify() -- cudaPreImageNetMean failed\n");
+			return -1;
+		}
 	}
 	
 	

--- a/imageNet.cu
+++ b/imageNet.cu
@@ -97,4 +97,49 @@ cudaError_t cudaPreImageNetMean( float4* input, size_t inputWidth, size_t inputH
 	return CUDA(cudaGetLastError());
 }
 
+// gpuPreImageNetMean
+__global__ void gpuPreImageNetMean( float2 scale, float4* input, int iWidth, float* output, int oWidth, int oHeight, float* mean_binary)
+{
+	const int x = blockIdx.x * blockDim.x + threadIdx.x;
+	const int y = blockIdx.y * blockDim.y + threadIdx.y;
+	const int n = oWidth * oHeight;
+	
+	if( x >= oWidth || y >= oHeight )
+		return;
+
+	const int dx = ((float)x * scale.x);
+	const int dy = ((float)y * scale.y);
+
+	const float4 px  = input[ dy * iWidth + dx ];
+	//const float3 mx  = mean_binary[ dy * iWidth + dx ];
+	//const float3 bgr = make_float3(px.z - mx.x, px.y - mx.y, px.x - mx.z);
+	
+	output[n * 0 + y * oWidth + x] = px.z - mean_binary[n * 0 + y * oWidth + x];
+	output[n * 1 + y * oWidth + x] = px.y - mean_binary[n * 1 + y * oWidth + x];
+	output[n * 2 + y * oWidth + x] = px.x - mean_binary[n * 2 + y * oWidth + x];
+}
+
+
+// cudaPreImageNetMean
+cudaError_t cudaPreImageNetMean( float4* input, size_t inputWidth, size_t inputHeight,
+				             float* output, size_t outputWidth, size_t outputHeight, float* mean_binary )
+{
+	if( !input || !output )
+		return cudaErrorInvalidDevicePointer;
+
+	if( inputWidth == 0 || outputWidth == 0 || inputHeight == 0 || outputHeight == 0 )
+		return cudaErrorInvalidValue;
+
+	const float2 scale = make_float2( float(inputWidth) / float(outputWidth),
+							    float(inputHeight) / float(outputHeight) );
+
+	// launch kernel
+	const dim3 blockDim(8, 8);
+	const dim3 gridDim(iDivUp(outputWidth,blockDim.x), iDivUp(outputHeight,blockDim.y));
+
+	gpuPreImageNetMean<<<gridDim, blockDim>>>(scale, input, inputWidth, output, outputWidth, outputHeight, mean_binary);
+
+	return CUDA(cudaGetLastError());
+}
+
 

--- a/tensorNet.h
+++ b/tensorNet.h
@@ -150,6 +150,9 @@ protected:
 	uint32_t mInputSize;
 	float*   mInputCPU;
 	float*   mInputCUDA;
+	float*   mMeanCPU;
+	float*   mMeanCUDA;
+
 	uint32_t mMaxBatchSize;
 	bool	 mEnableProfiler;
 	bool     mEnableDebug;

--- a/util/loadImage.cpp
+++ b/util/loadImage.cpp
@@ -160,6 +160,40 @@ bool loadImageRGB( const char* filename, float3** cpu, float3** gpu, int* width,
 	return true;
 }
 
+bool saveImageRGB( const char* filename, float3* cpu, int width, int height, float max_pixel )
+{
+	if( !filename || !cpu || !width || !height )
+	{
+		printf("saveImageRGBA - invalid parameter\n");
+		return false;
+	}
+	
+	const float scale = 255.0f / max_pixel;
+	QImage img(width, height, QImage::Format_RGB32);
+
+	for( int y=0; y < height; y++ )
+	{
+		for( int x=0; x < width; x++ )
+		{
+			const float3 px = cpu[y * width + x];
+			//printf("%03u %03u   %f\n", x, y, normPx);
+			img.setPixel(x, y, qRgb(px.x * scale, px.y * scale, px.z * scale));
+		}
+	}
+
+
+	/*
+	 * save file
+	 */
+	if( !img.save(filename/*, "PNG", 100*/) )
+	{
+		printf("failed to save %ix%i output image to %s\n", width, height, filename);
+		return false;
+	}
+	
+	return true;
+}
+
 
 // loadImageBGR
 bool loadImageBGR( const char* filename, float3** cpu, float3** gpu, int* width, int* height, const float3& mean )

--- a/util/loadImage.h
+++ b/util/loadImage.h
@@ -45,6 +45,11 @@ bool saveImageRGBA( const char* filename, float4* cpu, int width, int height, fl
  */
 bool loadImageRGB( const char* filename, float3** cpu, float3** gpu, int* width, int* height, const float3& mean=make_float3(0,0,0) );
 
+/**
+ * Save an image to disk
+ * @ingroup util
+ */
+bool saveImageRGB( const char* filename, float3* cpu, int width, int height, float max_pixel=255.0f );
 
 /**
  * Load a color image from disk into CUDA memory.


### PR DESCRIPTION
As the title says, I have added image mean subtraction support. Now we can pass the path to the mean binary file like this:

```
./imagenet-console input.png output_0.jpg \
--prototxt=$NET/deploy.prototxt \
--model=$NET/snapshot_iter_360.caffemodel \
--mean_binary=$NET/mean.binaryproto \
--labels=$NET/labels.txt \
--input_blob=data \
--output_blob=softmax
```

If no binary file is passed, it will run with the same preprocessing as before.

This fixes #86.
