### PR TITLE
Fix wrong NetworkType for imageNet

### DIFF
--- a/imageNet.cpp
+++ b/imageNet.cpp
@@ -87,6 +87,7 @@ bool imageNet::init( imageNet::NetworkType networkType, uint32_t maxBatchSize )
 	printf("%s initialized.\n", GetNetworkName());
 	return true;*/
 
+	mNetworkType = networkType;
 	if( networkType == imageNet::ALEXNET )
 		return init( "networks/alexnet.prototxt", "networks/bvlc_alexnet.caffemodel", NULL, "networks/ilsvrc12_synset_words.txt", IMAGENET_DEFAULT_INPUT, IMAGENET_DEFAULT_OUTPUT, maxBatchSize );
 	else if( networkType == imageNet::GOOGLENET )


### PR DESCRIPTION
The imagenet-camera seems weird when GL display shows that alexnet is used, but it actually uses googlenet, so I take a look to see imageNet doesn't set the type member correctly. This's just a tiny bug :).