### PR TITLE
add RGBAfToRGB

### DIFF
--- a/util/cuda/cudaRGB.h
+++ b/util/cuda/cudaRGB.h
@@ -34,5 +34,11 @@
  */
 cudaError_t cudaRGBToRGBAf( uchar3* input, float4* output, size_t width, size_t height );
 
+/**
+ * Convert 32-bit floating-point RGBA image to 8-bit fixed-point RGB image
+ * @ingroup util
+ */
+cudaError_t cudaRGBAfToRGB( float4* input, uchar3* output, size_t width, size_t height );
+
 
 #endif


### PR DESCRIPTION
cv::Mat objects store data in uchar3 format, RGBToRGBAf allowed people to use a cv::Mat as an input to a tensorNet.  By adding RGBAfToRGB you can now go the other direction.  Take the output of the tensorNet and store it in a cv::Mat.

Example:

```C++
// Load an image into a cv::Mat and convert it to RGB
Mat cvImageBGR;
Mat cvImageRGB;

cvImageBGR = imread("Sidewalk.png", CV_LOAD_IMAGE_COLOR);
cvtColor(cvImageBGR, cvImageRGB, CV_BGR2RGB);

int imgWidth = cvImage.size().width;
int imgHeight = cvImage.size().height;

// Allocate a cuda buffer
uchar3* imgBufferRGB = NULL;
cudaMalloc((void**)&imgBufferRGB, imgWidth * sizeof(uchar3) * imgHeight);

// Copy the data from the Mat into the cuda buffer
cudaMemcpy2D(
            (void*)imgBufferRGB,
            imgWidth*sizeof(uchar3),
            (void*)cvImage.data,
            cvImage.step,
            imgWidth*sizeof(uchar3),
            imgHeight,
            cudaMemcpyHostToDevice);

// Allocate a mapped buffer for input into the tensorNet
float4* imgCPU = NULL;
float4* imgCUDA = NULL;

if(!cudaAllocMapped((void**)&imgCPU, (void**)&imgCUDA, imgWidth * imgHeight * sizeof(float4)) )
{
    printf("failed to allocate CUDA memory for input image\n");
    return 0;
}

// Convert the RGB (uchar3) data to RGBAf (float4)
cudaRGBToRGBAf(imgBufferRGB, imgCUDA, imgWidth, imgHeight);

// Allocate another mapped buffer for the output of the tensorNet
float4* outCPU = NULL;
float4* outCUDA = NULL;

if(!cudaAllocMapped((void**)&outCPU, (void**)&outCUDA, imgWidth * imgHeight * sizeof(float4)) )
{
    printf("failed to allocate CUDA memory for output image\n");
    return 0;
}

// Run the tensornet (in this example segNet::Overlay)
if(!net->Overlay((float*)imgCUDA, (float*)outCUDA, imgWidth, imgHeight))
        printf("failed to process segmentation overlay.\n");

// Convert the image back to uchar3
cudaRGBAfToRGB(outCUDA, imgBufferRGB, shared->width, shared->height);

// Copy the output data into a new cv::Mat
Mat result;
cudaMemcpy2D(
        (void*)result.data,
        imgWidth*sizeof(uchar3),
        (void*)imgBufferRGB,
        result.step,
        imgWidth*sizeof(uchar3),
        imgHeight,
        cudaMemcpyDeviceToHost); 

```