### PR TITLE
Add binding to another overload of segNet::Mask

### DIFF
--- a/python/examples/segnet-camera.py
+++ b/python/examples/segnet-camera.py
@@ -55,7 +55,7 @@ net.SetOverlayAlpha(opt.alpha)
 
 # allocate the output images for the overlay & mask
 img_overlay = jetson.utils.cudaAllocMapped(opt.width * opt.height * 4 * ctypes.sizeof(ctypes.c_float))
-img_mask = jetson.utils.cudaAllocMapped(opt.width/2 * opt.height/2 * 4 * ctypes.sizeof(ctypes.c_float))
+img_mask = jetson.utils.cudaAllocMapped(opt.width * opt.height * ctypes.sizeof(ctypes.c_float))
 
 # create the camera and display
 camera = jetson.utils.gstCamera(opt.width, opt.height, opt.camera)
@@ -71,12 +71,12 @@ while display.IsOpen():
 
 	# generate the overlay and mask
 	net.Overlay(img_overlay, width, height, opt.filter_mode)
-	net.Mask(img_mask, width/2, height/2, opt.filter_mode)
+	net.Mask(img_mask, width // 2, height// 2, opt.filter_mode)
 
 	# render the images
 	display.BeginRender()
 	display.Render(img_overlay, width, height)
-	display.Render(img_mask, width/2, height/2, width)
+	display.Render(img_mask, width // 2, height // 2, width)
 	display.EndRender()
 
 	# update the title bar


### PR DESCRIPTION
- Add binding to another overload of segNet::Mask
- Use integer division in segnet-camera.py

Usage of the new python binding:

```python
classes = jetson.utils.cudaAllocMapped(width * height)
net.MaskClass(classes, width, height)
# cudaToNumpy assumes float32. Need to dividie output length by 4.
mask = jetson.utils.cudaToNumpy(classes, 1, width * height // 4, 1)[:, 0, 0]
# convert resulting float32 view to uint8 view
mask_np = mask.view('uint8').reshape(width, height)
```