### PR TITLE
Missing Glew in documentation.

### DIFF
--- a/docs/building-repo-2.md
+++ b/docs/building-repo-2.md
@@ -17,7 +17,7 @@ Here's a condensed form of the commands to download, build, and install the proj
 
 ``` bash
 $ sudo apt-get update
-$ sudo apt-get install git cmake libpython3-dev python3-numpy
+$ sudo apt-get install git cmake libpython3-dev python3-numpy libglew-dev
 $ git clone --recursive https://github.com/dusty-nv/jetson-inference
 $ cd jetson-inference
 $ mkdir build


### PR DESCRIPTION
I was  getting a missing header error to `GL/glew.h`. Installing the development package for glew (on a freshly-installed Jetson Nano), fixed this.