### PR TITLE
minor typo in invoking C++ program

### DIFF
--- a/docs/imagenet-console-2.md
+++ b/docs/imagenet-console-2.md
@@ -124,7 +124,7 @@ $ ./imagenet-console.py --network=resnet-18 images/stingray.jpg output_stingray.
 
 ``` bash
 # C++
-$ ./imagenet-console.py --network=resnet-18 images/coral.jpg output_coral.jpg
+$ ./imagenet-console --network=resnet-18 images/coral.jpg output_coral.jpg
 
 # Python
 $ ./imagenet-console.py --network=resnet-18 images/coral.jpg output_coral.jpg


### PR DESCRIPTION
Given the preceding C++ comment, the correct invocation should be ` ./imagenet-console ` instead of `./imagenet-console.py`