### PR TITLE
segNet: Add zero-copy class score getter

### DIFF
--- a/c/segNet.cpp
+++ b/c/segNet.cpp
@@ -661,6 +661,19 @@ bool segNet::Process( float* rgba, uint32_t width, uint32_t height, const char* 
 	return true;
 }
 
+bool segNet::GetClassScores( float** class_scores, uint32_t* width, uint32_t* height, uint32_t* num_classes )
+{
+	if ( mOutputs[0].CPU == NULL )
+	{
+		return false;
+	}
+	*class_scores = (float*) mOutputs[0].CPU;
+	*width = DIMS_W(mOutputs[0].dims);
+	*height = DIMS_H(mOutputs[0].dims);
+	*num_classes = DIMS_C(mOutputs[0].dims);
+	return true;
+}
+		
 
 // argmax classification
 bool segNet::classify( const char* ignore_class )

--- a/c/segNet.h
+++ b/c/segNet.h
@@ -189,6 +189,15 @@ public:
 	bool Process( float* input, uint32_t width, uint32_t height, const char* ignore_class="void" );
 
 	/**
+	 * Return per-pixel class probabilities, as well as number of classes and size of the output layer.
+	 * Does not perform a memory copy.
+	 * @param class_scores float pointer to destination array
+	 * @param width pointer to the variable that will hold the output layer width
+	 * @param height pointer to the variable that will hold the output layer height
+	 * @param num_classes pointer to the variable that will hold the number of classes
+	 */
+	 bool GetClassScores( float** class_scores, uint32_t* width, uint32_t* height, uint32_t* num_classes );
+	/**
 	 * Produce a grayscale binary segmentation mask, where the pixel values
 	 * correspond to the class ID of the corresponding class type.
 	 */


### PR DESCRIPTION
This PR adds a getter for class probabilities to segNet. 
This getter is zero-copy on a Jetson since all it does is return a pointer to the memory area containing non-argmaxed raw output. 
I noticed that segNet::Mask() and segNet::Overlay() do not argmax on GPU but on CPU, so there is no performance loss on performing argmax yourself and this can be useful if you want to do e.g. bilinear filtering on probabilities in order to get less "blocky" results. This is my use case, so I figured somebody else could use this. 