### PR TITLE
Fix for error when building in nvidia l4t docker image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ add_subdirectory(python)
 
 
 # set linker options
-target_link_libraries(jetson-inference jetson-utils nvinfer nvinfer_plugin nvcaffe_parser)
+target_link_libraries(jetson-inference jetson-utils nvinfer nvinfer_plugin nvparsers)
 
 if(CUDA_VERSION_MAJOR GREATER 9)
 	target_link_libraries(jetson-inference nvonnxparser)

--- a/tools/trt-bench/CMakeLists.txt
+++ b/tools/trt-bench/CMakeLists.txt
@@ -3,4 +3,4 @@ file(GLOB trtBenchSources *.cpp)
 file(GLOB trtBenchIncludes *.h )
 
 cuda_add_executable(trt-bench ${trtBenchSources})
-target_link_libraries(trt-bench nvcaffe_parser nvinfer jetson-inference)
+target_link_libraries(trt-bench nvparsers nvinfer jetson-inference)

--- a/tools/trt-console/CMakeLists.txt
+++ b/tools/trt-console/CMakeLists.txt
@@ -3,4 +3,4 @@ file(GLOB trtConsoleSources *.cpp)
 file(GLOB trtConsoleIncludes *.h )
 
 cuda_add_executable(trt-console ${trtConsoleSources})
-target_link_libraries(trt-console nvcaffe_parser nvinfer jetson-inference)
+target_link_libraries(trt-console nvparsers nvinfer jetson-inference)


### PR DESCRIPTION
Building now finishes without error when run on nvcr.io/nvidia/l4t-tensorflow docker image.
The issue was related to the nvcaffe_parser not being found. This libary's functionality is now in nvparsers library and so all links to this library should be switched in the CMakeLists.txt  files.