### PR TITLE
Corrected method in python example

### DIFF
--- a/docs/posenet.md
+++ b/docs/posenet.md
@@ -102,16 +102,19 @@ for pose in poses:
     # find the keypoint index from the list of detected keypoints
     # you can find these keypoint names in the model's JSON file, 
     # or with net.GetKeypointName() / net.GetNumKeypoints()
-    left_wrist_idx = net.FindKeypoint('left_wrist')
-    left_shoulder_idx = net.FindKeypoint('left_shoulder')
+    left_wrist_idx = net.FindKeypointID('left_wrist')
+    left_shoulder_idx = net.FindKeypointID('left_shoulder')
 
     # if the keypoint index is < 0, it means it wasn't found in the image
     if left_wrist_idx < 0 or left_shoulder_idx < 0:
         continue
+    try:
+    	left_wrist = pose.Keypoints[left_wrist_idx]
+    	left_shoulder = pose.Keypoints[left_shoulder_idx]
+    except IndexError:
+        print("keypoints not found.")
+        continue
 	
-    left_wrist = pose.Keypoints[left_wrist_idx]
-    left_shoulder = pose.Keypoints[left_shoulder_idx]
-
     point_x = left_shoulder.x - left_wrist.x
     point_y = left_shoulder.y - left_wrist.y
 


### PR DESCRIPTION
In the python example, it was used `FindKeypoint(...)` instead of `FindKeypointID(...)`.

Added IndexError exception handling because if there aren't _left_wrist_ and _left_shoulder_ key points in the image, the program will crash.