### PR TITLE
Fix download of Inception v4 model

### DIFF
--- a/tools/download-models.sh
+++ b/tools/download-models.sh
@@ -790,7 +790,7 @@ while true; do
 					download_vgg16
 				elif [ $model = 10 ] && [ -z $ALL_RECOGNITION ]; then
 					download_vgg19
-				elif [ $model = 8 ] && [ -z $ALL_RECOGNITION ]; then
+				elif [ $model = 11 ] && [ -z $ALL_RECOGNITION ]; then
 					download_inception_v4
 				elif [ $model = 12 ]; then
 					download_detection


### PR DESCRIPTION
The shell script was not correctly handling the download of Inception v4 model.