### PR TITLE
Update default camera flip docs

### DIFF
--- a/docs/aux-streaming.md
+++ b/docs/aux-streaming.md
@@ -73,9 +73,9 @@ As mentioned above, any of the examples from jetson-inference can be substituted
                              * mpeg2, mpeg4
                              * mjpeg
   --input-flip=FLIP      flip method to apply to input:
-                             * none (default)
+                             * none (default on Jetpack < 4)
                              * counterclockwise
-                             * rotate-180
+                             * rotate-180 (default on Jetpack >= 4)
                              * clockwise
                              * horizontal
                              * vertical


### PR DESCRIPTION
The defaults for camera flip are different for newer Jatpack versions (4+). [Here](https://github.com/dusty-nv/jetson-utils/blob/def4a04d023960781a44f9cd97fd1464093becf0/camera/gstCamera.cpp#L137-L143) is the relevant source code.