### PR TITLE
imagenet-example-2: imageNet::Create does not accept enums as arguments

### DIFF
--- a/docs/imagenet-example-2.md
+++ b/docs/imagenet-example-2.md
@@ -39,8 +39,8 @@ int main( int argc, char** argv )
 	}
 
 	// load the GoogleNet image recognition network with TensorRT
-	// you can use imageNet::RESNET_18 to load ResNet-18 model instead
-	imageNet* net = imageNet::Create(imageNet::GOOGLENET);
+	// you can use "resnet-18" to load ResNet-18 model instead
+	imageNet* net = imageNet::Create("googlenet");
 
 	// check to make sure that the network model loaded properly
 	if( !net )


### PR DESCRIPTION
No version of imageNet::Create accepts enum (NetworkType) arguments. But it does accept a char*. Thus, replacing imageNet::GOOGLENET with "googlenet" does the trick.