### PR TITLE
Update imagenet-example-2.md

### DIFF
--- a/docs/imagenet-example-2.md
+++ b/docs/imagenet-example-2.md
@@ -177,7 +177,7 @@ Using the [`imageNet::Create()`](../c/imageNet.h#L108) function, the following c
 ``` cpp
 	// load the GoogleNet image recognition network with TensorRT
 	// you can use imageNet::RESNET_18 to load ResNet-18 instead
-	imageNet* net = imageNet::Create(imageNet::GOOGLENET);
+	imageNet* net = imageNet::Create("googlenet");
 
 	// check to make sure that the network model loaded properly
 	if( !net )


### PR DESCRIPTION
Replaced  `imageNet* net = imageNet::Create(imageNet::GOOGLENET);` on **line 38** with `imageNet* net = imageNet::Create("googlenet");` because the former errored out with `/my-recognition/my-recognition.cpp:38:52: error: ‘GOOGLENET’ is not a member of ‘imageNet’` when running `make`

Device: Jetson Orin Nano
Version: nvidia-l4t-core 36.3.0-20240506102626