### PR TITLE
Fixed error with running l4t version > 36.3.0 

### DIFF
--- a/docker/tag.sh
+++ b/docker/tag.sh
@@ -31,6 +31,10 @@ if [ $ARCH = "aarch64" ]; then
 		if [ $L4T_REVISION_MAJOR -gt 4 ]; then
 			CONTAINER_TAG="r35.4.1"
 		fi
+	elif [ $L4T_RELEASE -eq 36 ]; then
+		if [ $L4T_REVISION_MAJOR -gt 3 ]; then
+			CONTAINER_TAG="r36.3.0"
+		fi
 	fi
 
 elif [ $ARCH = "x86_64" ]; then


### PR DESCRIPTION
docker/tag.sh fails with L4T release 36.4 since it looks for a container with that tag, but your highest container is 36.3.0 so this is the one that should be loaded. Simple check put in place just as you did for gt r34.4