### PR TITLE
More fixes for TensorRT 10

### DIFF
--- a/c/tensorNet.cpp
+++ b/c/tensorNet.cpp
@@ -1637,11 +1637,13 @@ bool tensorNet::LoadEngine( nvinfer1::ICudaEngine* engine,
 
 		LogVerbose(LOG_TRT "binding to output %i %s  binding index:  %i\n", n, output_blobs[n].c_str(), outputIndex);
 
+	#if NV_TENSORRT_MAJOR > 1
     #if NV_TENSORRT_MAJOR >= 10
         nvinfer1::Dims outputDims = engine->getTensorShape(output_blobs[n].c_str());
-	#elif NV_TENSORRT_MAJOR > 1
+	#else
 		nvinfer1::Dims outputDims = validateDims(engine->getBindingDimensions(outputIndex));
 
+	#endif
 	#if NV_TENSORRT_MAJOR >= 7
 		if( mModelType == MODEL_ONNX )
 			outputDims = shiftDims(outputDims);  // change NCHW to CHW if EXPLICIT_BATCH set
@@ -1664,7 +1666,7 @@ bool tensorNet::LoadEngine( nvinfer1::ICudaEngine* engine,
 			return false;
 		}
 	
-    #if NV_TENSORRT_MAJOR >= 10
+    #if 0 && NV_TENSORRT_MAJOR >= 10
         if( !mContext->setTensorAddress(output_blobs[n].c_str(), outputCUDA) )
         {
             LogError(LOG_TRT "failed to set input tensor address for %s (%zu bytes)\n", outputSize, output_blobs[n].c_str());


### PR DESCRIPTION
This change builds on the latest changes for TensorRT 10 - https://github.com/dusty-nv/jetson-inference/commit/c038530ebf718e6867c4458c3e439406020732ff. 

It fixes the following:
* Correctly rearrange the `#if` and `#endif` for `outputDims` similar to the `inputDims`. The issue is that the ONNX shiftDims was not being called due to a missing `#endif` after getting the `outputDims`.
* Do not call `setTensorAddress` for output dimensions. This was causing a segmentation fault so the fix is to not call it similarly to the way it is implemented for input tensors.

You can test this with `posenet` because this is the one of the few models that is using ONNX as its source.